### PR TITLE
[FE] D-Day 최대 10일 제한 및 마감 장학 처리 완료 (#4)

### DIFF
--- a/frontend/src/pages/ScholarshipCalendar.tsx
+++ b/frontend/src/pages/ScholarshipCalendar.tsx
@@ -322,6 +322,15 @@ export default function ScholarshipCalendar() {
 
                           return (
                             <>
+                              <button
+                                style={pillBtn}
+                                onClick={() =>
+                                  handleAlertSelect(it.id, 0, it.deadline)
+                                }
+                              >
+                                D-Day
+                              </button>
+
                               {dayOptions.map((n) => (
                                 <button
                                   key={n}
@@ -336,14 +345,6 @@ export default function ScholarshipCalendar() {
                                   D-{n}
                                 </button>
                               ))}
-                              <button
-                                style={pillBtn}
-                                onClick={() =>
-                                  handleAlertSelect(it.id, 0, it.deadline)
-                                }
-                              >
-                                마감일 당일
-                              </button>
                             </>
                           );
                         })()}

--- a/frontend/src/pages/ScholarshipCalendar.tsx
+++ b/frontend/src/pages/ScholarshipCalendar.tsx
@@ -256,6 +256,19 @@ export default function ScholarshipCalendar() {
                         )})`
                     : null;
 
+                const today = new Date();
+                const deadlineDate = new Date(it.deadline);
+                const diffDays = Math.floor(
+                  (deadlineDate.getTime() - today.getTime()) /
+                    (1000 * 60 * 60 * 24)
+                );
+
+                const isExpired = diffDays < 0;
+                const dayOptions = Array.from(
+                  { length: Math.min(diffDays, 10) }, // 최대 10일까지만
+                  (_, i) => i + 1
+                );
+
                 return (
                   <div key={it.id} style={itemCardStyle}>
                     <div
@@ -295,59 +308,45 @@ export default function ScholarshipCalendar() {
                       </button>
 
                       <button
-                        style={pillBtn}
+                        style={{
+                          ...pillBtn,
+                          opacity: isExpired ? 0.5 : 1,
+                          cursor: isExpired ? "not-allowed" : "pointer",
+                        }}
+                        disabled={isExpired}
                         onClick={() =>
+                          !isExpired &&
                           setShowDropdownFor(
                             showDropdownFor === it.id ? null : it.id
                           )
                         }
                       >
-                        알림일 추가
+                        {isExpired ? "마감" : "알림일 추가"}
                       </button>
                     </div>
 
-                    {showDropdownFor === it.id && (
+                    {showDropdownFor === it.id && !isExpired && (
                       <div style={{ marginTop: 10 }}>
-                        {(() => {
-                          const today = new Date();
-                          const deadlineDate = new Date(it.deadline);
-                          const diffDays = Math.floor(
-                            (deadlineDate.getTime() - today.getTime()) /
-                              (1000 * 60 * 60 * 24)
-                          );
-                          const dayOptions = Array.from(
-                            { length: diffDays },
-                            (_, i) => i + 1
-                          );
+                        <button
+                          style={pillBtn}
+                          onClick={() =>
+                            handleAlertSelect(it.id, 0, it.deadline)
+                          }
+                        >
+                          D-Day
+                        </button>
 
-                          return (
-                            <>
-                              <button
-                                style={pillBtn}
-                                onClick={() =>
-                                  handleAlertSelect(it.id, 0, it.deadline)
-                                }
-                              >
-                                D-Day
-                              </button>
-
-                              {dayOptions.map((n) => (
-                                <button
-                                  key={n}
-                                  style={{
-                                    ...pillBtn,
-                                    marginRight: 6,
-                                  }}
-                                  onClick={() =>
-                                    handleAlertSelect(it.id, n, it.deadline)
-                                  }
-                                >
-                                  D-{n}
-                                </button>
-                              ))}
-                            </>
-                          );
-                        })()}
+                        {dayOptions.map((n) => (
+                          <button
+                            key={n}
+                            style={{ ...pillBtn, marginRight: 6 }}
+                            onClick={() =>
+                              handleAlertSelect(it.id, n, it.deadline)
+                            }
+                          >
+                            D-{n}
+                          </button>
+                        ))}
                       </div>
                     )}
 
@@ -391,6 +390,7 @@ export default function ScholarshipCalendar() {
   );
 }
 
+/* --- 스타일 --- */
 const containerStyle: React.CSSProperties = {
   maxWidth: "500px",
   margin: "0 auto",


### PR DESCRIPTION
## 📚 Docs

> ex) #이슈번호, #이슈번호
#4 

## 💡 Changes

> 이번 PR에서 작업한 내용을 설명해주세요.

- D-Day 선택 최대 10일 제한
- 마감된 장학금은 알림일 설정 불가 처리
- 마감된 장학 카드 회색 표시 및 (마감) 라벨 추가
- 기존 기능(북마크, 알림일 추가) 정상 동작 확인 완료

> 핵심 코드가 있다면 코드 블록으로 작성하고, 코드에 대한 간단한 설명도 남겨주세요.

### 📸 images

> (선택사항)
<img width="545" height="548" alt="image" src="https://github.com/user-attachments/assets/8ada82cb-43dd-4788-b728-71d4486ccbaa" /><br>
- 11일 남은 장학 D-10까지만 표시 <br>

<img width="541" height="150" alt="image" src="https://github.com/user-attachments/assets/28865c21-fabe-4d82-8159-efc39c580673" /><br>
- 기간 지난 마감된 장학은 알림일 추가 불가능
