### PR TITLE
fix: 프론트 api 연동 위해 PK 반환

### DIFF
--- a/backend/src/mypage/serializers.py
+++ b/backend/src/mypage/serializers.py
@@ -200,8 +200,10 @@ class KeywordSerializer(serializers.ModelSerializer):
         fields = ['keyword']
 
     def to_representation(self, instance):
-        return instance.keyword
-
+        return {
+            "keyword_id": instance.keyword_id,
+            "keyword": instance.keyword
+        }
 
 class UserKeywordSerializer(serializers.ModelSerializer):
     keyword_id = serializers.IntegerField(write_only=True)
@@ -230,15 +232,16 @@ class UserKeywordSerializer(serializers.ModelSerializer):
 class CertificationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Certification
-        fields = ['certification_name', 'category']
+        fields = ['certification_id', 'certification_name', 'category']
 
 class UserCertificationListSerializer(serializers.ModelSerializer):
+    user_certification_id = serializers.IntegerField()
     certification_name = serializers.CharField(source="certification.certification_name")
     category = serializers.CharField(source="certification.category")
 
     class Meta:
         model = UserCertification
-        fields = ['certification_name', 'category']
+        fields = ['user_certification_id', 'certification_name', 'category']
 
 class UserCertificationSerializer(serializers.ModelSerializer):
     certification_name = serializers.CharField(source="certification.certification_name", read_only=True)


### PR DESCRIPTION
## 📚 Docs

> #16 

## 💡 Changes

> 프론트엔드 UI 활용을 위해 Response에 PK id 함께 반환하도록 수정
> ex) 사용자 자격증 목록에서 자격증 이름을 클릭하면 해당 사용자 자격증의 상세정보 화면으로 넘어가도록 연동 가능