### PR TITLE
feat: 회원가입 및 프로필 수정 시 income_level 처리 로직 정리

### DIFF
--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -74,18 +74,17 @@ export const majorOptions = [
 const yearOptions = ["1", "2", "3", "4"];
 
 const incomeOptions = [
-  { label: "1분위", value: 1 },
-  { label: "2분위", value: 2 },
-  { label: "3분위", value: 3 },
-  { label: "4분위", value: 4 },
-  { label: "5분위", value: 5 },
-  { label: "6분위", value: 6 },
-  { label: "7분위", value: 7 },
-  { label: "8분위", value: 8 },
-  { label: "9분위", value: 9 },
-  { label: "10분위", value: 10 },
+  { label: "1분위", value: "1분위" },
+  { label: "2분위", value: "2분위" },
+  { label: "3분위", value: "3분위" },
+  { label: "4분위", value: "4분위" },
+  { label: "5분위", value: "5분위" },
+  { label: "6분위", value: "6분위" },
+  { label: "7분위", value: "7분위" },
+  { label: "8분위", value: "8분위" },
+  { label: "9분위", value: "9분위" },
+  { label: "10분위", value: "10분위" },
 ];
-
 type Profile = {
   name: string;
   major: string | number;
@@ -335,10 +334,10 @@ const ProfilePage: React.FC = () => {
     const res = await apiRequest("http://127.0.0.1:8000/mypage/me/", {
       method: "PATCH",
       body: JSON.stringify({
-        major: form.major,
-        year: form.grade,
+        major: Number(form.major),
+        year: String(form.grade),
         gpa: form.gpa,
-        income_level: form.incomeLevel,
+        income_level: form.incomeLevel === "" ? null : form.incomeLevel,
         receive_notifications: form.receiveNotifications,
       }),
     });
@@ -348,7 +347,9 @@ const ProfilePage: React.FC = () => {
       setEditInfo(false);
       loadMyInfo();
     } else {
-      alert("저장 실패");
+      const errorData = await res.json();
+      console.log("❌ PATCH ERROR:", errorData); // ⭐ 에러확인
+      alert("저장 실패: " + JSON.stringify(errorData));
     }
   };
 
@@ -614,9 +615,8 @@ const ProfilePage: React.FC = () => {
                   }
                   style={selectStyle}
                 >
-                  {/* <option value="">선택</option> */}
                   {incomeOptions.map((opt) => (
-                    <option key={opt.label} value={opt.label}>
+                    <option key={opt.value} value={opt.value}>
                       {opt.label}
                     </option>
                   ))}

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -108,6 +108,9 @@ const Signup: React.FC = () => {
         newErrors.gpa = "학점은 0~4.50 사이여야 합니다.";
     }
 
+    // 🔥 추가된 부분: 소득분위 필수 처리
+    if (!incomeLevel.trim()) newErrors.incomeLevel = "소득분위를 선택해주세요.";
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -129,11 +132,8 @@ const Signup: React.FC = () => {
       major: Number(major),
       year,
       gpa: Number(gpa),
+      income_level: incomeLevel, // 🔥 필수값이라 조건문 제거
     };
-
-    if (incomeLevel.trim() !== "") {
-      signupData.income_level = incomeLevel;
-    }
 
     navigate("/signup-step2", { state: signupData });
   };
@@ -246,7 +246,7 @@ const Signup: React.FC = () => {
               borderRadius: "8px",
               padding: "12px",
               marginBottom: "0.4rem",
-              color: major ? "#333" : "#888",
+              color: year ? "#333" : "#888",
             }}
           >
             <option value="">학년 선택</option>
@@ -271,9 +271,13 @@ const Signup: React.FC = () => {
           />
           {errors.gpa && <p style={errorText}>{errors.gpa}</p>}
 
+          {/* 소득분위 영역 */}
           <select
             value={incomeLevel}
-            onChange={(e) => setIncomeLevel(e.target.value)}
+            onChange={(e) => {
+              setIncomeLevel(e.target.value);
+              setErrors((prev) => ({ ...prev, incomeLevel: "" }));
+            }}
             style={{
               ...inputWithError("incomeLevel"),
               width: "100%",
@@ -283,7 +287,7 @@ const Signup: React.FC = () => {
               color: incomeLevel ? "#333" : "#888",
             }}
           >
-            <option value="">소득분위 (선택 없음)</option>
+            <option value="">소득분위 선택</option>
             <option value="1분위">1분위</option>
             <option value="2분위">2분위</option>
             <option value="3분위">3분위</option>
@@ -295,6 +299,7 @@ const Signup: React.FC = () => {
             <option value="9분위">9분위</option>
             <option value="10분위">10분위</option>
           </select>
+          {errors.incomeLevel && <p style={errorText}>{errors.incomeLevel}</p>}
 
           <button style={buttonStyle} onClick={handleNext}>
             다음 단계


### PR DESCRIPTION
## 📚 Docs

> ex) #70

## 💡 Changes

> 이번 PR에서 작업한 내용을 설명해주세요.
 
마이페이지에서 소득분위를 1 에서 10분위만 선택할 수 있도록 수정
(선택 없음 추가 시 백엔드 ChoiceField와 충돌 → 추후 백엔드 수정 후 재도입 예정)
회원가입 화면도 동일 기준으로 1 에서 10분위만 선택 가능하도록 정리


> 핵심 코드가 있다면 코드 블록으로 작성하고, 코드에 대한 간단한 설명도 남겨주세요.

### 📸 images

> (선택사항)
