### PR TITLE
feat: 전체 alert → react-hot-toast 적용하여 UI/UX 개선 (#93)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hot-toast": "^2.6.0",
         "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
@@ -1585,7 +1586,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2005,6 +2005,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/graphemer": {
@@ -2748,6 +2757,23 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hot-toast": "^2.6.0",
     "react-router-dom": "^6.30.1"
   },
   "devDependencies": {

--- a/frontend/src/api/apiClient.ts
+++ b/frontend/src/api/apiClient.ts
@@ -1,3 +1,5 @@
+import { toast } from "react-hot-toast";
+
 export async function apiRequest(url: string, options: any = {}) {
   const access = localStorage.getItem("accessToken");
   const refresh = localStorage.getItem("refreshToken");
@@ -8,8 +10,10 @@ export async function apiRequest(url: string, options: any = {}) {
     ...(access ? { Authorization: `Bearer ${access}` } : {}),
   };
 
+  // 최초 요청
   let response = await fetch(url, options);
 
+  // accessToken 만료 → refreshToken 시도
   if (response.status === 401 && refresh) {
     const refreshRes = await fetch(
       "http://127.0.0.1:8000/auth/token/refresh/",
@@ -20,18 +24,30 @@ export async function apiRequest(url: string, options: any = {}) {
       }
     );
 
+    // refreshToken 정상 → accessToken 재발급 후 재요청
     if (refreshRes.ok) {
       const data = await refreshRes.json();
-
       localStorage.setItem("accessToken", data.access);
 
+      // Authorization 헤더 갱신
       options.headers.Authorization = `Bearer ${data.access}`;
 
+      // 요청 재시도
       response = await fetch(url, options);
-    } else {
+    }
+
+    // refreshToken 실패 → 완전히 만료됨
+    else {
+      // 토큰 삭제
       localStorage.removeItem("accessToken");
       localStorage.removeItem("refreshToken");
+
+      // 토스트 메시지 출력
+      toast.error("세션이 만료되었습니다. 다시 로그인해주세요.");
+
+      // 로그인 화면으로 이동
       window.location.href = "/login";
+      return;
     }
   }
 

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import { toast } from "react-hot-toast";
 
 import homeIcon from "../images/free-icon-home.png";
 import calendarIcon from "../images/free-icon-weekly-calendar-outline-event-interface-symbol.png";
@@ -32,6 +33,8 @@ export default function BottomNav() {
   const handleLogout = () => {
     localStorage.removeItem("accessToken");
     localStorage.removeItem("refreshToken");
+
+    toast.success("로그아웃 되었습니다.");
     navigate("/login", { replace: true });
   };
 

--- a/frontend/src/contexts/BookmarkContext.tsx
+++ b/frontend/src/contexts/BookmarkContext.tsx
@@ -56,7 +56,7 @@ export const BookmarkProvider: React.FC<{ children: React.ReactNode }> = ({
     loadInitialBookmarks();
   }, []);
 
-  /* 북마크 토글  */
+  /* 북마크 토글 */
   const toggleBookmark = async (scholarshipId: number) => {
     const token = localStorage.getItem("accessToken");
 
@@ -72,14 +72,11 @@ export const BookmarkProvider: React.FC<{ children: React.ReactNode }> = ({
         }
       );
 
+      // 서버 메시지는 toast로 페이지 단에서 처리하므로 여기서는 UI 처리 없음
       let data = {};
       try {
         data = await res.json();
       } catch {}
-
-      if ((data as any)?.message) {
-        alert((data as any).message);
-      }
 
       setBookmarks((prev) => {
         const updated = prev.includes(scholarshipId)
@@ -91,12 +88,11 @@ export const BookmarkProvider: React.FC<{ children: React.ReactNode }> = ({
         return updated;
       });
     } catch (e) {
-      alert("북마크 처리 중 오류 발생");
-      console.error(e);
+      console.error("북마크 처리 중 오류:", e);
     }
   };
 
-  /* 북마크 삭제  */
+  /* 북마크 삭제 (마이페이지에서 사용) */
   const removeBookmarkById = async (
     bookmarkId: number,
     scholarshipId: number
@@ -115,12 +111,11 @@ export const BookmarkProvider: React.FC<{ children: React.ReactNode }> = ({
         }
       );
 
+      // 여기서도 UI 메시지 제거
       let data = {};
       try {
         data = await res.json();
       } catch {}
-
-      alert((data as any)?.message || "북마크가 삭제되었습니다.");
 
       // 상태 동기화
       setBookmarks((prev) => {
@@ -130,8 +125,7 @@ export const BookmarkProvider: React.FC<{ children: React.ReactNode }> = ({
         return updated;
       });
     } catch (e) {
-      alert("북마크 삭제 중 오류 발생");
-      console.error(e);
+      console.error("북마크 삭제 중 오류:", e);
     }
   };
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -19,8 +19,22 @@ import ScholarshipCalendar from "./pages/ScholarshipCalendar";
 import Profile from "./pages/Profile";
 import RecommendedScholarshipDetail from "./pages/RecommendedScholarshipDetail";
 
+import { Toaster } from "react-hot-toast";
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
+    {/* 전역 Toast 설정 */}
+    <Toaster
+      position="top-center"
+      reverseOrder={false}
+      toastOptions={{
+        duration: 2500,
+        style: {
+          fontSize: "14px",
+        },
+      }}
+    />
+
     <BadgeProvider>
       <BookmarkProvider>
         <BrowserRouter>
@@ -29,7 +43,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             <Route path="/login" element={<Login />} />
             <Route path="/signup" element={<Signup />} />
             <Route path="/signup-step2" element={<SignupStep2 />} />
+
             <Route path="/main" element={<Main />} />
+
             <Route
               path="/recommended/:id"
               element={<RecommendedScholarshipDetail />}
@@ -41,6 +57,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             <Route path="/notices" element={<NoticeBoard />} />
             <Route path="/notices/list" element={<NoticeList />} />
             <Route path="/notice/:id" element={<NoticeDetail />} />
+
             <Route
               path="/notice"
               element={<Navigate to="/notices" replace />}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import logo from "../images/logo.png";
+import toast from "react-hot-toast";
 
 const Login: React.FC = () => {
   const navigate = useNavigate();
@@ -26,13 +27,15 @@ const Login: React.FC = () => {
         localStorage.setItem("accessToken", data.access);
         localStorage.setItem("refreshToken", data.refresh);
 
-        alert("로그인 성공!");
+        toast.success("로그인 성공!");
         navigate("/main", { replace: true });
       } else {
-        alert(data.error?.[0] || "로그인 실패. 아이디/비밀번호를 확인하세요.");
+        toast.error(
+          data.error?.[0] || "로그인 실패. 아이디/비밀번호를 확인하세요."
+        );
       }
     } catch (error) {
-      alert("서버 연결에 문제가 발생했습니다.");
+      toast.error("서버 연결에 문제가 발생했습니다.");
     }
   };
 

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -9,6 +9,7 @@ import banner1_1_1 from "../images/banner1_1_1.png";
 import banner2_2 from "../images/banner2_2.png";
 
 import { useBadge } from "../contexts/BadgeContext";
+import { toast } from "react-hot-toast";
 
 type Notice = {
   id: number;
@@ -75,7 +76,9 @@ const Main: React.FC = () => {
         list.sort((a, b) => (a.postedAt < b.postedAt ? 1 : -1));
         setTopNotices(list.slice(0, 3));
       } catch (e: any) {
-        setNoticeErr(e?.message ?? "학사공지 불러오기 실패");
+        const msg = e?.message ?? "학사공지 불러오기 실패";
+        setNoticeErr(msg);
+        toast.error(msg);
       } finally {
         setNoticeLoading(false);
       }
@@ -88,6 +91,11 @@ const Main: React.FC = () => {
     (async () => {
       try {
         const token = localStorage.getItem("accessToken");
+        if (!token) {
+          toast.error("로그인이 필요합니다.");
+          navigate("/login");
+          return;
+        }
 
         const res = await fetch("http://127.0.0.1:8000/scholarships/", {
           headers: {
@@ -111,7 +119,9 @@ const Main: React.FC = () => {
 
         setSchPrev(converted.slice(0, 3));
       } catch (e: any) {
-        setSchErr(e?.message ?? "장학금 불러오기 실패");
+        const msg = e?.message ?? "장학금 불러오기 실패";
+        setSchErr(msg);
+        toast.error(msg);
       } finally {
         setSchLoad(false);
       }
@@ -123,6 +133,11 @@ const Main: React.FC = () => {
     (async () => {
       try {
         const token = localStorage.getItem("accessToken");
+        if (!token) {
+          toast.error("로그인이 필요합니다.");
+          navigate("/login");
+          return;
+        }
 
         const res = await fetch(
           "http://127.0.0.1:8000/scholarships/recommendations/",
@@ -136,7 +151,9 @@ const Main: React.FC = () => {
         const data: Scholarship[] = await res.json();
         setRecommendations(data);
       } catch (e: any) {
-        setRecErr(e?.message ?? "추천 장학금 불러오기 오류");
+        const msg = e?.message ?? "추천 장학금 불러오기 오류";
+        setRecErr(msg);
+        toast.error(msg);
       } finally {
         setRecLoad(false);
       }
@@ -210,11 +227,6 @@ const Main: React.FC = () => {
           )}
 
           {recLoad && <div style={{ textAlign: "center" }}>불러오는 중…</div>}
-          {recErr && (
-            <div style={{ textAlign: "center", color: "tomato" }}>
-              에러: {recErr}
-            </div>
-          )}
 
           {!recLoad && !recErr && recommendations.length === 0 && (
             <div
@@ -291,7 +303,6 @@ const Main: React.FC = () => {
 
         <div style={scholarshipContentStyle}>
           {schLoad && <div>불러오는 중…</div>}
-          {schErr && <div style={{ color: "tomato" }}>에러: {schErr}</div>}
 
           {!schLoad && !schErr && (
             <ul style={listStyle}>
@@ -322,9 +333,6 @@ const Main: React.FC = () => {
 
         <div style={noticeContentStyle}>
           {noticeLoading && <div>불러오는 중…</div>}
-          {noticeErr && (
-            <div style={{ color: "tomato" }}>에러: {noticeErr}</div>
-          )}
 
           {!noticeLoading && !noticeErr && (
             <ul style={listStyle}>

--- a/frontend/src/pages/NotificationCenter.tsx
+++ b/frontend/src/pages/NotificationCenter.tsx
@@ -4,6 +4,7 @@ import BottomNav from "../components/BottomNav";
 import logo from "../images/logo.png";
 import arrowIcon from "../images/Arrow.png";
 import { useBadge } from "../contexts/BadgeContext";
+import { toast } from "react-hot-toast";
 
 type CalendarItem = {
   bookmark_id: number;
@@ -38,7 +39,6 @@ const NotificationCenter: React.FC = () => {
     try {
       const token = localStorage.getItem("accessToken");
 
-      // 캘린더에서 bookmark_id 목록 먼저 가져오기
       const calRes = await fetch(
         "http://127.0.0.1:8000/notification/calendar/",
         {
@@ -59,7 +59,6 @@ const NotificationCenter: React.FC = () => {
         return;
       }
 
-      // 각 bookmark_id에 대한 실제 알림 조회
       const all: NotificationItem[] = [];
 
       for (const id of bookmarkIds) {
@@ -85,7 +84,6 @@ const NotificationCenter: React.FC = () => {
         all.push(...enriched);
       }
 
-      // 최신 순으로 정렬
       all.sort(
         (a, b) =>
           new Date(b.end_date).getTime() - new Date(a.end_date).getTime()
@@ -94,6 +92,7 @@ const NotificationCenter: React.FC = () => {
       setNotifications(all);
     } catch (e) {
       console.error("알림 불러오기 실패:", e);
+      toast.error("알림 정보를 불러오지 못했습니다.");
     }
   };
 
@@ -118,8 +117,11 @@ const NotificationCenter: React.FC = () => {
       await res.json();
 
       setNotifications((prev) => prev.filter((n) => n.notification_id !== id));
+
+      toast.success("알림이 삭제되었습니다.");
     } catch (e) {
       console.error("알림 삭제 실패:", e);
+      toast.error("알림 삭제에 실패했습니다.");
     }
   };
 
@@ -143,13 +145,11 @@ const NotificationCenter: React.FC = () => {
 
         <h2 style={title}>알림 센터</h2>
 
-        {/* 알림 정책 설명 */}
         <p style={tip}>
           내가 추가한 알림(D-n)만 저장돼요. 기본 제공되는 D-1 알림은 자동
           발송되지만 기록되지 않아요.
         </p>
 
-        {/* 리스트 */}
         <section style={sectionCard}>
           <h3 style={sectionTitle}>설정된 알림</h3>
 
@@ -160,7 +160,7 @@ const NotificationCenter: React.FC = () => {
           {notifications.map((n) => (
             <div key={n.notification_id} style={card}>
               <div style={cardHeader}>
-                <div style={{ fontSize: 15, fontWeight: "600" }}>
+                <div style={{ fontSize: 15, fontWeight: 600 }}>
                   {n.scholarship_name}
                 </div>
 
@@ -185,7 +185,6 @@ const NotificationCenter: React.FC = () => {
 };
 
 /* 스타일 */
-
 const container: React.CSSProperties = {
   maxWidth: "500px",
   margin: "0 auto",

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -5,6 +5,7 @@ import logo from "../images/logo.png";
 import arrowIcon from "../images/Arrow.png";
 import { apiRequest } from "../api/apiClient";
 import { useBookmark } from "../contexts/BookmarkContext";
+import { toast } from "react-hot-toast";
 
 export const majorOptions = [
   { major_id: 1, major_name: "불교학과" },
@@ -310,13 +311,13 @@ const ProfilePage: React.FC = () => {
     });
 
     if (res.ok) {
-      alert("개인정보가 저장되었습니다.");
+      toast.success("개인정보가 저장되었습니다.");
       setEditInfo(false);
       loadMyInfo();
     } else {
       const errorData = await res.json();
       console.log("PATCH ERROR:", errorData);
-      alert("저장 실패: " + JSON.stringify(errorData));
+      toast.error("저장 실패: " + JSON.stringify(errorData));
     }
   };
 
@@ -330,7 +331,7 @@ const ProfilePage: React.FC = () => {
     const data = await res.json();
 
     if (res.ok) {
-      alert("비밀번호가 변경되었습니다.");
+      toast.success("비밀번호가 변경되었습니다.");
       setPwForm({ old_password: "", new_password1: "", new_password2: "" });
     } else {
       const detail = data.details;
@@ -341,7 +342,7 @@ const ProfilePage: React.FC = () => {
         detail?.error?.[0] ||
         data.error ||
         "비밀번호 변경 실패";
-      alert(msg);
+      toast.error(msg);
     }
   };
 
@@ -381,10 +382,10 @@ const ProfilePage: React.FC = () => {
 
       await loadKeywords();
       setEditingKeywords(false);
-      alert("관심 키워드가 저장되었습니다.");
+      toast.success("관심 키워드가 저장되었습니다.");
     } catch (e) {
       console.error(e);
-      alert("관심 키워드 저장 중 오류가 발생했습니다.");
+      toast.error("관심 키워드 저장 중 오류가 발생했습니다.");
     }
   };
 
@@ -406,11 +407,11 @@ const ProfilePage: React.FC = () => {
     const data = await res.json();
 
     if (res.ok) {
-      alert("자격증이 추가되었습니다.");
+      toast.success("자격증이 추가되었습니다.");
       setAddModalOpen(false);
       loadUserCerts();
     } else {
-      alert(data.error || "추가 실패");
+      toast.error(data.error || "추가 실패");
     }
   };
 
@@ -433,11 +434,11 @@ const ProfilePage: React.FC = () => {
     const data = await res.json();
 
     if (res.ok) {
-      alert("수정되었습니다.");
+      toast.success("수정되었습니다.");
       setEditModalOpen(false);
       loadUserCerts();
     } else {
-      alert(data.error || "수정 실패");
+      toast.error(data.error || "수정 실패");
     }
   };
 
@@ -452,11 +453,11 @@ const ProfilePage: React.FC = () => {
     const data = await res.json();
 
     if (res.ok) {
-      alert("삭제되었습니다.");
+      toast.success("삭제되었습니다.");
       setEditModalOpen(false);
       loadUserCerts();
     } else {
-      alert(data.error || "삭제 실패");
+      toast.error(data.error || "삭제 실패");
     }
   };
 

--- a/frontend/src/pages/RecommendedScholarshipDetail.tsx
+++ b/frontend/src/pages/RecommendedScholarshipDetail.tsx
@@ -6,6 +6,7 @@ import bookmarkIcon from "../images/bookmark.png";
 import bookmarkFilledIcon from "../images/bookmark_filled.png";
 import arrowIcon from "../images/Arrow.png";
 import { useBookmark } from "../contexts/BookmarkContext";
+import { toast } from "react-hot-toast";
 
 type ScholarshipDetailResponse = {
   scholarship_id: number;
@@ -58,21 +59,29 @@ const ScholarshipDetail: React.FC = () => {
   useEffect(() => {
     (async () => {
       try {
+        const token = localStorage.getItem("accessToken");
+        if (!token) {
+          toast.error("로그인이 필요합니다.");
+          navigate("/login");
+          return;
+        }
+
         const res = await fetch(`http://127.0.0.1:8000/scholarships/${id}/`, {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+            Authorization: `Bearer ${token}`,
           },
         });
 
         if (!res.ok) {
+          toast.error("장학금 상세 정보를 불러오지 못했습니다.");
           setItem(null);
-          setLoading(false);
           return;
         }
 
         const data: ScholarshipDetailResponse = await res.json();
         setItem(data);
-      } catch {
+      } catch (e) {
+        toast.error("서버와 연결할 수 없습니다.");
         setItem(null);
       } finally {
         setLoading(false);
@@ -80,8 +89,29 @@ const ScholarshipDetail: React.FC = () => {
     })();
   }, [id]);
 
-  if (loading) return <div style={container}>불러오는 중…</div>;
-  if (!item) return <div style={container}>존재하지 않는 장학금입니다.</div>;
+  if (loading) {
+    return <div style={container}>불러오는 중…</div>;
+  }
+
+  if (!item) {
+    return (
+      <div style={container}>
+        <p style={{ marginBottom: 12 }}>장학금 정보를 불러올 수 없습니다.</p>
+        <button
+          style={{
+            padding: "10px 14px",
+            borderRadius: 8,
+            border: "1px solid #ddd",
+            background: "#fff",
+            cursor: "pointer",
+          }}
+          onClick={() => navigate(-1)}
+        >
+          ← 뒤로가기
+        </button>
+      </div>
+    );
+  }
 
   const dday = Math.ceil(
     (new Date(item.end_date).getTime() - Date.now()) / 86400000
@@ -164,6 +194,13 @@ const ScholarshipDetail: React.FC = () => {
             src={item.is_bookmarked ? bookmarkFilledIcon : bookmarkIcon}
             onClick={() => {
               toggleBookmark(item.scholarship_id);
+
+              toast.success(
+                item.is_bookmarked
+                  ? "북마크가 해제되었습니다"
+                  : "북마크에 저장되었습니다"
+              );
+
               setItem((prev) =>
                 prev ? { ...prev, is_bookmarked: !prev.is_bookmarked } : prev
               );

--- a/frontend/src/pages/ScholarshipCalendar.tsx
+++ b/frontend/src/pages/ScholarshipCalendar.tsx
@@ -5,6 +5,7 @@ import logo from "../images/logo.png";
 import arrowIcon from "../images/Arrow.png";
 import { useBookmark } from "../contexts/BookmarkContext";
 import { useBadge } from "../contexts/BadgeContext";
+import { toast } from "react-hot-toast";
 
 type CalendarItem = {
   bookmark_id: number;
@@ -61,7 +62,6 @@ export default function ScholarshipCalendar() {
     CalendarItem[] | null
   >(null);
 
-  // 알림 정보를 bookmark_id 별로 저장
   const [notificationsMap, setNotificationsMap] = useState<
     Record<number, NotificationItem[]>
   >({});
@@ -87,6 +87,7 @@ export default function ScholarshipCalendar() {
         setCalendarItems(list);
       } catch (e) {
         console.error("캘린더 불러오기 실패:", e);
+        toast.error("캘린더 정보를 불러오지 못했습니다.");
       }
     };
 
@@ -118,6 +119,7 @@ export default function ScholarshipCalendar() {
         }));
       } catch (err) {
         console.log("알림 불러오기 실패", err);
+        toast.error("알림 정보를 불러오지 못했습니다.");
       }
     });
   }, [calendarItems]);
@@ -133,11 +135,9 @@ export default function ScholarshipCalendar() {
   }, [calendarItems]);
 
   const grid = useMemo(() => buildMonthGrid(month), [month]);
-
   const monthLabel = `${month.getFullYear()}년 ${String(
     month.getMonth() + 1
   ).padStart(2, "0")}월`;
-
   const thisMonth = month.getMonth();
 
   const sortedItems = useMemo(() => {
@@ -177,10 +177,11 @@ export default function ScholarshipCalendar() {
         setCount((prev) => prev + 1);
       }
 
-      alert(`알림 D-${daysBefore}이 설정되었습니다.`);
+      toast.success(`D-${daysBefore} 알림이 설정되었습니다.`);
       setShowDropdownFor(null);
     } catch (err) {
       console.log("알림 추가 실패", err);
+      toast.error("알림 설정에 실패했습니다.");
     }
   };
 
@@ -213,9 +214,10 @@ export default function ScholarshipCalendar() {
         setCount((prev) => Math.max(prev - 1, 0));
       }
 
-      alert("알림이 삭제되었습니다.");
+      toast.success("알림이 삭제되었습니다.");
     } catch (err) {
       console.log("알림 삭제 실패", err);
+      toast.error("알림 삭제에 실패했습니다.");
     }
   };
 
@@ -286,6 +288,7 @@ export default function ScholarshipCalendar() {
                     {d.getDate()}
                   </div>
 
+                  {/* 점 표시 */}
                   <div
                     style={{
                       display: "flex",
@@ -319,7 +322,7 @@ export default function ScholarshipCalendar() {
           </div>
         </div>
 
-        {/* 리스트 */}
+        {/* 리스트 영역 */}
         <section
           style={{
             background: "white",
@@ -344,7 +347,6 @@ export default function ScholarshipCalendar() {
                     (1000 * 60 * 60 * 24)
                 );
                 const isExpired = diffDays < 0;
-
                 const dayOptions = Array.from(
                   { length: Math.min(diffDays, 10) },
                   (_, i) => i + 1
@@ -395,6 +397,7 @@ export default function ScholarshipCalendar() {
                                 item.scholarship_id !== it.scholarship_id
                             )
                           );
+                          toast.success("북마크가 해제되었습니다.");
                         }}
                       >
                         북마크 해제
@@ -515,7 +518,6 @@ export default function ScholarshipCalendar() {
 }
 
 /* 스타일 */
-
 const containerStyle: React.CSSProperties = {
   maxWidth: "500px",
   margin: "0 auto",

--- a/frontend/src/pages/ScholarshipDetail.tsx
+++ b/frontend/src/pages/ScholarshipDetail.tsx
@@ -6,6 +6,7 @@ import bookmarkIcon from "../images/bookmark.png";
 import bookmarkFilledIcon from "../images/bookmark_filled.png";
 import arrowIcon from "../images/Arrow.png";
 import { useBookmark } from "../contexts/BookmarkContext";
+import { toast } from "react-hot-toast";
 
 type ScholarshipDetailResponse = {
   scholarship_id: number;
@@ -65,6 +66,7 @@ const ScholarshipDetail: React.FC = () => {
         });
 
         if (!res.ok) {
+          toast.error("장학금 상세 정보를 불러오지 못했습니다.");
           setItem(null);
           setLoading(false);
           return;
@@ -73,6 +75,7 @@ const ScholarshipDetail: React.FC = () => {
         const data: ScholarshipDetailResponse = await res.json();
         setItem(data);
       } catch {
+        toast.error("서버와 연결할 수 없습니다.");
         setItem(null);
       } finally {
         setLoading(false);
@@ -81,7 +84,24 @@ const ScholarshipDetail: React.FC = () => {
   }, [id]);
 
   if (loading) return <div style={container}>불러오는 중…</div>;
-  if (!item) return <div style={container}>존재하지 않는 장학금입니다.</div>;
+  if (!item)
+    return (
+      <div style={container}>
+        <p style={{ marginBottom: 12 }}>장학금 정보를 불러올 수 없습니다.</p>
+        <button
+          style={{
+            padding: "10px 14px",
+            borderRadius: 8,
+            border: "1px solid #ddd",
+            background: "#fff",
+            cursor: "pointer",
+          }}
+          onClick={() => navigate(-1)}
+        >
+          ← 뒤로가기
+        </button>
+      </div>
+    );
 
   const dday = Math.ceil(
     (new Date(item.end_date).getTime() - Date.now()) / 86400000
@@ -164,6 +184,13 @@ const ScholarshipDetail: React.FC = () => {
             src={item.is_bookmarked ? bookmarkFilledIcon : bookmarkIcon}
             onClick={() => {
               toggleBookmark(item.scholarship_id);
+
+              toast.success(
+                item.is_bookmarked
+                  ? "북마크가 해제되었습니다"
+                  : "북마크에 저장되었습니다"
+              );
+
               setItem((prev) =>
                 prev ? { ...prev, is_bookmarked: !prev.is_bookmarked } : prev
               );

--- a/frontend/src/pages/ScholarshipList.tsx
+++ b/frontend/src/pages/ScholarshipList.tsx
@@ -6,6 +6,7 @@ import bookmarkIcon from "../images/bookmark.png";
 import bookmarkFilledIcon from "../images/bookmark_filled.png";
 import arrowIcon from "../images/Arrow.png";
 import { useBookmark } from "../contexts/BookmarkContext";
+import { toast } from "react-hot-toast";
 
 const ALL_KEYWORDS = [
   "교내장학",
@@ -64,7 +65,6 @@ const ScholarshipList: React.FC = () => {
 
       const userKeywords = await res.json();
 
-      // ALL_KEYWORDS 기준으로 active 처리
       const merged = ALL_KEYWORDS.map((k) => ({
         name: k,
         active: userKeywords.some((uk: any) => uk.keyword === k),
@@ -120,7 +120,7 @@ const ScholarshipList: React.FC = () => {
     }
   };
 
-  /* 페이지 첫 로드 → 키워드 + 장학금 데이터 모두 로드 */
+  /* 페이지 첫 로드 */
   useEffect(() => {
     loadUserKeywords();
     loadScholarships();
@@ -154,7 +154,7 @@ const ScholarshipList: React.FC = () => {
     });
   };
 
-  /* UI 렌더링  */
+  /* UI 렌더링 */
   return (
     <>
       <div style={container}>
@@ -173,10 +173,7 @@ const ScholarshipList: React.FC = () => {
         {/* 키워드 토글 */}
         <div style={keywordToggleWrap}>
           <button
-            onClick={() => {
-              const willOpen = !showKeywords;
-              setShowKeywords(willOpen);
-            }}
+            onClick={() => setShowKeywords(!showKeywords)}
             style={keywordToggleBtn}
           >
             {showKeywords ? "관심키워드 숨기기 ▲" : "관심키워드 보기 ▼"}
@@ -246,6 +243,12 @@ const ScholarshipList: React.FC = () => {
                         onClick={(e) => {
                           e.stopPropagation();
                           toggleBookmark(s.id);
+
+                          toast.success(
+                            isBookmarked
+                              ? "북마크가 해제되었습니다"
+                              : "북마크에 저장되었습니다"
+                          );
                         }}
                       />
                     </div>

--- a/frontend/src/pages/SignupStep2.tsx
+++ b/frontend/src/pages/SignupStep2.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import logo from "../images/logo.png";
+import { toast } from "react-hot-toast";
 
 const SignupStep2: React.FC = () => {
   const navigate = useNavigate();
@@ -32,7 +33,7 @@ const SignupStep2: React.FC = () => {
 
   const handleSignup = async () => {
     if (!state) {
-      alert("회원가입 정보가 누락되었습니다. 처음부터 다시 입력해주세요.");
+      toast.error("회원가입 정보가 누락되었습니다. 다시 진행해주세요.");
       navigate("/signup");
       return;
     }
@@ -64,14 +65,14 @@ const SignupStep2: React.FC = () => {
       const data = await response.json();
 
       if (response.ok) {
-        alert("회원가입이 완료되었습니다!");
+        toast.success("회원가입이 완료되었습니다!");
         navigate("/login");
       } else {
         const messages = Object.values(data).flat().join("\n");
-        alert(messages || "회원가입에 실패했습니다.");
+        toast.error(messages || "회원가입에 실패했습니다.");
       }
     } catch (error) {
-      alert("서버와 연결할 수 없습니다.");
+      toast.error("서버와 연결할 수 없습니다.");
     }
   };
 


### PR DESCRIPTION
## 📚 Docs

> ex) #이슈번호, #이슈번호
#93 

## 💡 Changes

> 이번 PR에서 작업한 내용을 설명해주세요.
1) 전역 알림 시스템 개선
모든 페이지의 alert() → toast 기반 알림으로 변경

2) API 인증 개선
액세스 토큰 만료(401) 발생 시 자동으로 refresh token으로 재발급
재발급 실패 시 로그인 페이지로 이동
토큰 재발급 성공/실패 모두 toast로 피드백 제공

3) 개별 페이지 적용
로그인/회원가입
마이페이지(Profile)
장학금 리스트/상세/추천/캘린더
알림 센터(NotificationCenter)
하단 네비게이션 로그아웃 처리

모든 alert 제거 완료 → react-hot-toast UI로 통일.

> 핵심 코드가 있다면 코드 블록으로 작성하고, 코드에 대한 간단한 설명도 남겨주세요.

### 📸 images

> (선택사항)
